### PR TITLE
Fix Hyper-V install command, was missing a space

### DIFF
--- a/provision-hyper-v.ps1
+++ b/provision-hyper-v.ps1
@@ -1,5 +1,5 @@
 if (Get-Command -ErrorAction SilentlyContinue Install-WindowsFeature) {
-    Install-WindowsFeature Microsoft-Hyper-V-All
+    Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All
 } else {
-    Enable-WindowsOptionalFeature -Online -NoRestart -FeatureName Microsoft-Hyper-V-All
+    Enable-WindowsOptionalFeature -Online -NoRestart -FeatureName Microsoft-Hyper-V -All
 }


### PR DESCRIPTION
Found that the provision-hyper-v.ps1 was throwing an error.

This article shows the command, seems to have been missing a space.

Can't find the equivalent of Install-Windows feature, left both branches to be Enable-WindowsOptionalFeature.